### PR TITLE
fix: stabilize SVI2 power reporting and support clang-built kernels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,12 @@ KERNEL_BUILD	:= $(KERNEL_MODULES)/build
 endif
 endif
 
+KERNEL_AUTO_CONF := $(KERNEL_BUILD)/include/config/auto.conf
+VMLINUX_CC_IS_CLANG := $(shell grep -qs '^CONFIG_CC_IS_CLANG=y' $(KERNEL_AUTO_CONF) && echo 1)
+ifeq ($(VMLINUX_CC_IS_CLANG),1)
+LLVM ?= 1
+endif
+
 obj-m	:= $(patsubst %,%.o,zenpower)
 obj-ko	:= $(patsubst %,%.ko,zenpower)
 zenpower-objs := zenpower_core.o zenpower_svi2.o zenpower_rapl.o zenpower_temp.o
@@ -27,10 +33,10 @@ zenpower-objs := zenpower_core.o zenpower_svi2.o zenpower_rapl.o zenpower_temp.o
 all: modules
 
 modules:
-	@$(MAKE) -C $(KERNEL_BUILD) M=$(CURDIR) modules
+	@$(MAKE) -C $(KERNEL_BUILD) M=$(CURDIR) $(if $(LLVM),LLVM=$(LLVM)) modules
 
 clean:
-	@$(MAKE) -C $(KERNEL_BUILD) M=$(CURDIR) clean
+	@$(MAKE) -C $(KERNEL_BUILD) M=$(CURDIR) $(if $(LLVM),LLVM=$(LLVM)) clean
 
 dkms-install:
 	dkms --version >> /dev/null

--- a/zenpower_core.c
+++ b/zenpower_core.c
@@ -460,9 +460,15 @@ static int zenpower_read(struct device *dev, enum hwmon_sensor_types type,
 						zenpower_svi2_get_soc_current(plane, data->zen2);
 					break;
 				case hwmon_power:
-					*val = (channel == 0) ?
-						zenpower_svi2_get_core_current(plane, data->zen2) * zenpower_svi2_plane_to_vcc(plane):
-						zenpower_svi2_get_soc_current(plane, data->zen2) * zenpower_svi2_plane_to_vcc(plane);
+					if (channel == 0) {
+						u64 p = (u64)zenpower_svi2_get_core_current(plane, data->zen2) *
+							 (u64)zenpower_svi2_plane_to_vcc(plane);
+						*val = (long)p;
+					} else {
+						u64 p = (u64)zenpower_svi2_get_soc_current(plane, data->zen2) *
+							 (u64)zenpower_svi2_plane_to_vcc(plane);
+						*val = (long)p;
+					}
 					break;
 				default:
 					break;

--- a/zenpower_svi2.c
+++ b/zenpower_svi2.c
@@ -18,10 +18,17 @@
 u32 zenpower_svi2_plane_to_vcc(u32 plane)
 {
 	u32 vdd_cor;
+	s32 v;
 
 	vdd_cor = (plane >> 16) & 0xff;
 
-	return 1550 - ((625 * vdd_cor) / 100);
+	v = 1550 - (s32)((625 * vdd_cor) / 100);
+	if (v < 0)
+		v = 0;
+	else if (v > 2000)
+		v = 2000;
+
+	return (u32)v;
 }
 
 /*


### PR DESCRIPTION
- Clamp SVI2 voltage to 0..2000 mV to prevent underflow/overflow spikes that could produce massive power values on bad reads.
- Use 64-bit intermediate for power calculation (I*V) to avoid overflow.
- Auto-detect CONFIG_CC_IS_CLANG=y and pass LLVM=1 to kbuild so the module builds correctly on clang-built kernels without manual flags.
- No changes to hwmon interfaces or sensor names.

Fixes noisy/erratic power readings on Zen3 and resolves build failures on clang-built kernels (e.g., recent Cachyos LTO).